### PR TITLE
feat(apps): #1254 add sync atoms button to admin page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,11 @@
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "json.format.enable": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/apps/web/pages/admin/index.tsx
+++ b/apps/web/pages/admin/index.tsx
@@ -3,6 +3,7 @@ import { CodelabPage } from '@codelab/frontend/abstract/props'
 import {
   ResetDataButton,
   SeedBaseTypesButton,
+  SyncAtoms,
 } from '@codelab/frontend/modules/admin'
 import { ContentSection } from '@codelab/frontend/view/sections'
 import {
@@ -20,6 +21,7 @@ const AdminPage: CodelabPage<DashboardTemplateProps> = () => {
       <Space>
         <ResetDataButton />
         <SeedBaseTypesButton />
+        <SyncAtoms />
       </Space>
     </ContentSection>
   )

--- a/apps/web/pages/api/graphql.ts
+++ b/apps/web/pages/api/graphql.ts
@@ -5,48 +5,58 @@ import { createProxyMiddleware } from 'http-proxy-middleware'
 
 const app = express()
 
-app.use('*', async (baseReq, baseRes, next) => {
-  const session = await getSession(baseReq, baseRes as ServerResponse)
+export const createApiProxyMiddlewareHandler = (env: 'prod' | 'local') => {
+  const baseEndpoint =
+    env === 'prod'
+      ? process.env.CODELAB_API_ENDPOINT
+      : process.env.CODELAB_API_ENDPOINT
 
-  // Need to use 127.0.0.1
-  // https://github.com/chimurai/http-proxy-middleware/issues/171
-  return createProxyMiddleware({
-    target: process.env.CODELAB_API_ENDPOINT + '/graphql',
-    changeOrigin: true,
-    proxyTimeout: 30000,
-    secure: false,
-    logLevel: 'silent',
-    headers: {
-      Connection: 'keep-alive',
-    },
-    pathRewrite: {
-      '^/api/graphql': '',
-    },
-    cookieDomainRewrite: 'localhost',
-    onError: (err, req, res) => {
-      console.error(err, res.statusCode)
-      res.writeHead(500, {
-        'Content-Type': 'text/plain',
-      })
-      res.end('Something went wrong.')
-    },
-    onProxyReq: (proxyReq, req, res) => {
-      // console.log(req.headers.authorization)
-      // console.log(session?.accessToken)
+  return async (baseReq: any, baseRes: any, next: any) => {
+    const session = await getSession(baseReq, baseRes as ServerResponse)
+    const target = baseEndpoint + '/graphql'
 
-      if (session) {
-        proxyReq.setHeader('Authorization', `Bearer ${session.accessToken}`)
-      } else if (req.headers.authorization) {
-        // For SSR session is null, so we instead we use getSession inside getServerSideProps to set graphql request client auth headers
-        proxyReq.setHeader('Authorization', req.headers.authorization)
-      }
+    // Need to use 127.0.0.1
+    // https://github.com/chimurai/http-proxy-middleware/issues/171
+    return createProxyMiddleware({
+      target,
+      changeOrigin: true,
+      proxyTimeout: 30000,
+      secure: false,
+      logLevel: 'silent',
+      headers: {
+        Connection: 'keep-alive',
+      },
+      pathRewrite: {
+        '^prod/api/graphql': '',
+      },
+      cookieDomainRewrite: 'localhost',
+      onError: (err, req, res) => {
+        console.error(err, res.statusCode)
+        res.writeHead(500, {
+          'Content-Type': 'text/plain',
+        })
+        res.end('Something went wrong.')
+      },
+      onProxyReq: (proxyReq, req, res) => {
+        // console.log(req.headers.authorization)
+        // console.log(session?.accessToken)
 
-      if (process.env.DG_ADMIN_API_KEY) {
-        proxyReq.setHeader('Dg-Auth', process.env.DG_ADMIN_API_KEY)
-      }
-    },
-  })(baseReq, baseRes, next)
-})
+        if (session) {
+          proxyReq.setHeader('Authorization', `Bearer ${session.accessToken}`)
+        } else if (req.headers.authorization) {
+          // For SSR session is null, so we instead we use getSession inside getServerSideProps to set graphql request client auth headers
+          proxyReq.setHeader('Authorization', req.headers.authorization)
+        }
+
+        if (process.env.DG_ADMIN_API_KEY) {
+          proxyReq.setHeader('Dg-Auth', process.env.DG_ADMIN_API_KEY)
+        }
+      },
+    })(baseReq, baseRes, next)
+  }
+}
+
+app.use('*', createApiProxyMiddlewareHandler('local'))
 
 export const config = {
   api: {

--- a/apps/web/pages/api/prod/graphql.ts
+++ b/apps/web/pages/api/prod/graphql.ts
@@ -1,0 +1,10 @@
+import express from 'express'
+import { config, createApiProxyMiddlewareHandler } from '../graphql'
+
+const app = express()
+
+app.use('*', createApiProxyMiddlewareHandler('prod'))
+
+export { config }
+
+export default app

--- a/libs/backend/abstract/codegen/src/nestjs-types.api.graphql.gen.ts
+++ b/libs/backend/abstract/codegen/src/nestjs-types.api.graphql.gen.ts
@@ -44,6 +44,12 @@ export enum MonacoLanguage {
     Graphql = "Graphql"
 }
 
+export enum Role {
+    Admin = "Admin",
+    User = "User",
+    Guest = "Guest"
+}
+
 export enum AtomType {
     HookQueryLambda = "HookQueryLambda",
     HookQueryConfig = "HookQueryConfig",
@@ -412,6 +418,41 @@ export enum AtomType {
     HtmlSup = "HtmlSup"
 }
 
+export interface GetAppInput {
+    byId?: Nullable<AppByIdFilter>;
+    byPage?: Nullable<AppByPageFilter>;
+}
+
+export interface AppByIdFilter {
+    appId: string;
+}
+
+export interface AppByPageFilter {
+    pageId: string;
+}
+
+export interface ExportAppInput {
+    appId: string;
+}
+
+export interface GetElementGraphInput {
+    where: WhereUniqueElement;
+}
+
+export interface WhereUniqueElement {
+    id?: Nullable<string>;
+    fixedId?: Nullable<string>;
+}
+
+export interface GetElementInput {
+    where: WhereUniqueElement;
+}
+
+export interface GetComponentsInput {
+    searchQuery?: Nullable<string>;
+    componentIds?: Nullable<string[]>;
+}
+
 export interface GetAtomsInput {
     where?: Nullable<AtomsWhereInput>;
 }
@@ -477,6 +518,170 @@ export interface FieldByInterfaceFilter {
 
 export interface FieldByIdFilter {
     fieldId: string;
+}
+
+export interface GetPagesInput {
+    byApp: PageByAppFilter;
+}
+
+export interface PageByAppFilter {
+    appId: string;
+}
+
+export interface GetPageInput {
+    pageId: string;
+}
+
+export interface GetUserInput {
+    id?: Nullable<string>;
+    auth0Id?: Nullable<string>;
+}
+
+export interface GetUsersInput {
+    page: number;
+    perPage: number;
+    query: string;
+    sort: string;
+}
+
+export interface GetLambdaInput {
+    lambdaId: string;
+}
+
+export interface GetTagInput {
+    where: WhereUniqueTag;
+}
+
+export interface WhereUniqueTag {
+    name?: Nullable<string>;
+    id?: Nullable<string>;
+}
+
+export interface GetTagsInput {
+    ids?: Nullable<string[]>;
+}
+
+export interface GetTagGraphsInput {
+    where?: Nullable<TagsWhereInput>;
+}
+
+export interface TagsWhereInput {
+    ids?: Nullable<string[]>;
+}
+
+export interface CreateAppInput {
+    name: string;
+}
+
+export interface UpdateAppInput {
+    id: string;
+    data: UpdateAppData;
+}
+
+export interface UpdateAppData {
+    name: string;
+}
+
+export interface DeleteAppInput {
+    appId: string;
+}
+
+export interface ImportAppInput {
+    payload: string;
+}
+
+export interface CreatePropMapBindingInput {
+    elementId: string;
+    targetElementId?: Nullable<string>;
+    sourceKey: string;
+    targetKey: string;
+}
+
+export interface UpdatePropMapBindingInput {
+    propMapBindingId: string;
+    elementId: string;
+    data: UpdatePropMapBindingData;
+}
+
+export interface UpdatePropMapBindingData {
+    targetElementId?: Nullable<string>;
+    sourceKey: string;
+    targetKey: string;
+}
+
+export interface DeletePropMapBindingInput {
+    elementId: string;
+    propMapBindingIds: string[];
+}
+
+export interface AddHookToElementInput {
+    elementId: string;
+    config: string;
+    type: AtomType;
+}
+
+export interface RemoveHookFromElementInput {
+    elementId: string;
+    hookId: string;
+}
+
+export interface CreateElementInput {
+    parentElementId?: Nullable<string>;
+    name?: Nullable<string>;
+    css?: Nullable<string>;
+    atomId?: Nullable<string>;
+    order?: Nullable<number>;
+    props?: Nullable<string>;
+    instanceOfComponentId?: Nullable<string>;
+}
+
+export interface UpdateElementInput {
+    data: UpdateElementData;
+    id: string;
+}
+
+export interface UpdateElementData {
+    name?: Nullable<string>;
+    atomId?: Nullable<string>;
+    instanceOfComponentId?: Nullable<string>;
+    css?: Nullable<string>;
+    renderForEachPropKey?: Nullable<string>;
+    renderIfPropKey?: Nullable<string>;
+    propTransformationJs?: Nullable<string>;
+}
+
+export interface MoveElementInput {
+    elementId: string;
+    moveData: MoveData;
+}
+
+export interface MoveData {
+    order: number;
+    parentElementId?: Nullable<string>;
+}
+
+export interface DuplicateElementInput {
+    elementId: string;
+}
+
+export interface UpdateElementPropsInput {
+    data: string;
+    elementId: string;
+}
+
+export interface DeleteElementInput {
+    elementId: string;
+}
+
+export interface ConvertElementToComponentInput {
+    elementId: string;
+    componentName?: Nullable<string>;
+}
+
+export interface CreateComponentInput {
+    name?: Nullable<string>;
+    props?: Nullable<string>;
+    atomId?: Nullable<string>;
 }
 
 export interface CreateAtomInput {
@@ -631,6 +836,95 @@ export interface DeleteFieldInput {
     fieldId: string;
 }
 
+export interface CreatePageInput {
+    name: string;
+    appId: string;
+}
+
+export interface DeletePageInput {
+    pageId: string;
+}
+
+export interface UpdatePageInput {
+    pageId: string;
+    updateData: UpdatePageData;
+}
+
+export interface UpdatePageData {
+    name: string;
+}
+
+export interface UpsertUserInput {
+    data: UpsertUserDataInput;
+    where?: Nullable<UserWhereUniqueInput>;
+}
+
+export interface UpsertUserDataInput {
+    auth0Id: string;
+    roles: Role[];
+}
+
+export interface UserWhereUniqueInput {
+    id?: Nullable<string>;
+    auth0Id?: Nullable<string>;
+}
+
+export interface DeleteUserInput {
+    id: string;
+}
+
+export interface CreateLambdaInput {
+    name: string;
+    body: string;
+}
+
+export interface DeleteLambdaInput {
+    lambdaId: string;
+}
+
+export interface UpdateLambdaInput {
+    name: string;
+    body: string;
+    id: string;
+}
+
+export interface ExecuteLambdaInput {
+    lambdaId: string;
+    payload?: Nullable<string>;
+}
+
+export interface CreateTagInput {
+    name: string;
+    parentTagId?: Nullable<string>;
+}
+
+export interface UpdateTagInput {
+    id: string;
+    data: UpdateTagData;
+}
+
+export interface UpdateTagData {
+    name: string;
+}
+
+export interface DeleteTagsInput {
+    ids: string[];
+}
+
+export interface UpsertTagInput {
+    data: CreateTagInput;
+    where?: Nullable<TagWhereUniqueInput>;
+}
+
+export interface TagWhereUniqueInput {
+    id?: Nullable<string>;
+    name?: Nullable<string>;
+}
+
+export interface ImportTagsInput {
+    payload: string;
+}
+
 export interface TypeEdge {
     source: string;
     target: string;
@@ -643,7 +937,7 @@ export interface Type {
     typeGraph: TypeGraph;
 }
 
-export interface CreateResponse {
+export interface ObjectRef {
     id: string;
 }
 
@@ -777,6 +1071,20 @@ export interface TypeGraph {
     edges: TypeEdge[];
 }
 
+export interface CreateResponse {
+    id: string;
+}
+
+export interface PayloadResponse {
+    payload: string;
+}
+
+export interface User {
+    id: string;
+    auth0Id: string;
+    roles: Role[];
+}
+
 export interface Atom {
     id: string;
     type: AtomType;
@@ -785,7 +1093,106 @@ export interface Atom {
     apiGraph: TypeGraph;
 }
 
+export interface Prop {
+    id: string;
+    data: string;
+}
+
+export interface Hook {
+    id: string;
+    type: AtomType;
+    config: Prop;
+}
+
+export interface Tag {
+    id: string;
+    name: string;
+    owner?: Nullable<ObjectRef>;
+    parent?: Nullable<string>;
+    children: string[];
+    isRoot: boolean;
+}
+
+export interface TagEdge {
+    source: string;
+    target: string;
+    order?: Nullable<number>;
+}
+
+export interface TagGraph {
+    vertices: TagVertex[];
+    edges: TagEdge[];
+}
+
+export interface PropMapBinding {
+    id: string;
+    targetElementId?: Nullable<string>;
+    sourceKey: string;
+    targetKey: string;
+}
+
+export interface Element {
+    id: string;
+    name?: Nullable<string>;
+    componentTag?: Nullable<Tag>;
+    fixedId?: Nullable<string>;
+    css?: Nullable<string>;
+    atom?: Nullable<Atom>;
+    props: Prop;
+    hooks: Hook[];
+    renderForEachPropKey?: Nullable<string>;
+    renderIfPropKey?: Nullable<string>;
+    propMapBindings: PropMapBinding[];
+    propTransformationJs?: Nullable<string>;
+    instanceOfComponent?: Nullable<ObjectRef>;
+    parentElement?: Nullable<ObjectRef>;
+    owner?: Nullable<ObjectRef>;
+    graph: ElementGraph;
+}
+
+export interface ElementEdge {
+    source: string;
+    target: string;
+    order?: Nullable<number>;
+}
+
+export interface ElementGraph {
+    vertices: Element[];
+    edges: ElementEdge[];
+}
+
+export interface Page {
+    id: string;
+    name: string;
+    elements?: Nullable<ElementGraph>;
+    rootElementId: string;
+}
+
+export interface App {
+    id: string;
+    ownerId: string;
+    name: string;
+    pages: Page[];
+}
+
+export interface Lambda {
+    id: string;
+    ownerId: string;
+    name: string;
+    body: string;
+}
+
+export interface LambdaPayload {
+    payload: string;
+}
+
 export interface IQuery {
+    getApp(input: GetAppInput): Nullable<App> | Promise<Nullable<App>>;
+    getApps(): App[] | Promise<App[]>;
+    exportApp(input: ExportAppInput): PayloadResponse | Promise<PayloadResponse>;
+    getElementGraph(input: GetElementGraphInput): ElementGraph | Promise<ElementGraph>;
+    getElement(input: GetElementInput): Nullable<Element> | Promise<Nullable<Element>>;
+    getComponents(input?: Nullable<GetComponentsInput>): Element[] | Promise<Element[]>;
     getAtomsTypeHook(): Nullable<Atom[]> | Promise<Nullable<Atom[]>>;
     getAtoms(input?: Nullable<GetAtomsInput>): Nullable<Atom[]> | Promise<Nullable<Atom[]>>;
     getAtom(input: GetAtomInput): Nullable<Atom> | Promise<Nullable<Atom>>;
@@ -793,9 +1200,38 @@ export interface IQuery {
     getTypeGraph(input: GetTypeGraphInput): Nullable<TypeGraph> | Promise<Nullable<TypeGraph>>;
     getTypes(input?: Nullable<GetTypesInput>): Type[] | Promise<Type[]>;
     getField(input: GetFieldInput): Nullable<Field> | Promise<Nullable<Field>>;
+    getProp(): Prop | Promise<Prop>;
+    getPages(input: GetPagesInput): Page[] | Promise<Page[]>;
+    getPage(input: GetPageInput): Nullable<Page> | Promise<Nullable<Page>>;
+    getMe(): Nullable<User> | Promise<Nullable<User>>;
+    getUser(input: GetUserInput): Nullable<User> | Promise<Nullable<User>>;
+    getUsers(input?: Nullable<GetUsersInput>): User[] | Promise<User[]>;
+    getLambda(input: GetLambdaInput): Nullable<Lambda> | Promise<Nullable<Lambda>>;
+    getLambdas(): Lambda[] | Promise<Lambda[]>;
+    getTag(input: GetTagInput): Nullable<Tag> | Promise<Nullable<Tag>>;
+    getTags(input?: Nullable<GetTagsInput>): Tag[] | Promise<Tag[]>;
+    getTagGraph(): Nullable<TagGraph> | Promise<Nullable<TagGraph>>;
+    getTagGraphs(input?: Nullable<GetTagGraphsInput>): TagGraph | Promise<TagGraph>;
 }
 
 export interface IMutation {
+    createApp(input: CreateAppInput): App | Promise<App>;
+    updateApp(input: UpdateAppInput): Nullable<App> | Promise<Nullable<App>>;
+    deleteApp(input: DeleteAppInput): Nullable<App> | Promise<Nullable<App>>;
+    importApp(input: ImportAppInput): App | Promise<App>;
+    createPropMapBinding(input: CreatePropMapBindingInput): PropMapBinding | Promise<PropMapBinding>;
+    updatePropMapBinding(input: UpdatePropMapBindingInput): Nullable<PropMapBinding> | Promise<Nullable<PropMapBinding>>;
+    deletePropMapBinding(input: DeletePropMapBindingInput): Nullable<PropMapBinding[]> | Promise<Nullable<PropMapBinding[]>>;
+    addHookToElement(input: AddHookToElementInput): Hook | Promise<Hook>;
+    removeHookFromElement(input: RemoveHookFromElementInput): Nullable<Hook> | Promise<Nullable<Hook>>;
+    createElement(input: CreateElementInput): Element | Promise<Element>;
+    updateElement(input: UpdateElementInput): Element | Promise<Element>;
+    moveElement(input: MoveElementInput): Element | Promise<Element>;
+    duplicateElement(input: DuplicateElementInput): Element | Promise<Element>;
+    updateElementProps(input: UpdateElementPropsInput): Element | Promise<Element>;
+    deleteElement(input: DeleteElementInput): Element | Promise<Element>;
+    convertElementToComponent(input: ConvertElementToComponentInput): Element | Promise<Element>;
+    createComponent(input: CreateComponentInput): Element | Promise<Element>;
     createAtom(input: CreateAtomInput): Atom | Promise<Atom>;
     deleteAtom(input: DeleteAtomInput): Nullable<Atom> | Promise<Nullable<Atom>>;
     importAtoms(input: ImportAtomsInput): Nullable<Void> | Promise<Nullable<Void>>;
@@ -812,8 +1248,24 @@ export interface IMutation {
     createField(input: CreateFieldInput): Field | Promise<Field>;
     updateField(input: UpdateFieldInput): Nullable<Field> | Promise<Nullable<Field>>;
     deleteField(input: DeleteFieldInput): Nullable<Field> | Promise<Nullable<Field>>;
+    createPage(input: CreatePageInput): Page | Promise<Page>;
+    deletePage(input: DeletePageInput): Page | Promise<Page>;
+    updatePage(input: UpdatePageInput): Page | Promise<Page>;
+    upsertUser(input: UpsertUserInput): User | Promise<User>;
+    deleteUser(input: DeleteUserInput): boolean | Promise<boolean>;
+    resetData(): Nullable<Void> | Promise<Nullable<Void>>;
+    createLambda(input: CreateLambdaInput): Lambda | Promise<Lambda>;
+    deleteLambda(input: DeleteLambdaInput): Lambda | Promise<Lambda>;
+    updateLambda(input: UpdateLambdaInput): Nullable<Lambda> | Promise<Nullable<Lambda>>;
+    executeLambda(input: ExecuteLambdaInput): Nullable<LambdaPayload> | Promise<Nullable<LambdaPayload>>;
+    createTag(input: CreateTagInput): Tag | Promise<Tag>;
+    updateTag(input: UpdateTagInput): Nullable<Tag> | Promise<Nullable<Tag>>;
+    deleteTags(input: DeleteTagsInput): Nullable<Tag[]> | Promise<Nullable<Tag[]>>;
+    upsertTag(input: UpsertTagInput): Tag | Promise<Tag>;
+    importTags(input: ImportTagsInput): Nullable<Void> | Promise<Nullable<Void>>;
 }
 
 export type Void = any;
 export type TypeVertex = EnumType | PrimitiveType | ArrayType | ComponentType | ElementType | InterfaceType | LambdaType | PageType | AppType | RenderPropsType | ReactNodeType | UnionType | MonacoType;
+export type TagVertex = Tag;
 type Nullable<T> = T | null;

--- a/libs/backend/infra/src/decorators/guards/gql-auth.guard.ts
+++ b/libs/backend/infra/src/decorators/guards/gql-auth.guard.ts
@@ -5,11 +5,23 @@ import { AuthGuard } from '@nestjs/passport'
 /**
  * Checks for user authentication only, doesn't account for role-based permissions
  */
+
+const getRequest = (context: ExecutionContext) => {
+  const ctx = GqlExecutionContext.create(context)
+
+  return ctx.getContext().req
+}
+
 @Injectable()
 export class GqlAuthGuard extends AuthGuard('jwt') {
   getRequest(context: ExecutionContext) {
-    const ctx = GqlExecutionContext.create(context)
+    return getRequest(context)
+  }
+}
 
-    return ctx.getContext().req
+@Injectable()
+export class GqlAllEnvAuthGuard extends AuthGuard(['jwt', 'jwt_local']) {
+  getRequest(context: ExecutionContext) {
+    return getRequest(context)
   }
 }

--- a/libs/backend/modules/atom/src/application/atom.resolver.ts
+++ b/libs/backend/modules/atom/src/application/atom.resolver.ts
@@ -1,5 +1,9 @@
 import { Void } from '@codelab/backend/abstract/types'
-import { GqlAuthGuard, RolesGuard } from '@codelab/backend/infra'
+import {
+  GqlAllEnvAuthGuard,
+  GqlAuthGuard,
+  RolesGuard,
+} from '@codelab/backend/infra'
 import { GetTypeGraphService, TypeGraph } from '@codelab/backend/modules/type'
 import { CurrentUser, Roles } from '@codelab/backend/modules/user'
 import { IUser, Role } from '@codelab/shared/abstract/core'
@@ -85,7 +89,7 @@ export class AtomResolver {
   }
 
   @Query(() => [Atom], { nullable: true })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAllEnvAuthGuard)
   async getAtoms(@Args('input', { nullable: true }) input?: GetAtomsInput) {
     return this.getAtomsService.execute(input)
   }

--- a/libs/backend/modules/user/src/auth.module.ts
+++ b/libs/backend/modules/user/src/auth.module.ts
@@ -1,7 +1,7 @@
 import { Global, Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { PassportModule } from '@nestjs/passport'
-import { JwtStrategy } from './infra/auth'
+import { JwtLocalStrategy, JwtStrategy } from './infra/auth'
 import { auth0Config, Auth0Module } from './infra/auth0'
 import { GetUserService } from './use-cases/get-user'
 import { UpsertUserService } from './use-cases/upsert-user'
@@ -14,7 +14,7 @@ import { UpsertUserService } from './use-cases/upsert-user'
     // JwtModule.register({}),
     ConfigModule.forFeature(auth0Config),
   ],
-  providers: [JwtStrategy, GetUserService, UpsertUserService],
+  providers: [JwtStrategy, JwtLocalStrategy, GetUserService, UpsertUserService],
   exports: [],
 })
 export class AuthModule {}

--- a/libs/backend/modules/user/src/infra/auth/index.ts
+++ b/libs/backend/modules/user/src/infra/auth/index.ts
@@ -1,3 +1,4 @@
 export * from './decorators/current-user.decorator'
 export * from './decorators/roles.decorator'
+export * from './jwt.local.strategy'
 export * from './jwt.strategy'

--- a/libs/backend/modules/user/src/infra/auth/jwt.local.strategy.ts
+++ b/libs/backend/modules/user/src/infra/auth/jwt.local.strategy.ts
@@ -1,4 +1,3 @@
-import { IUser, Role } from '@codelab/shared/abstract/core'
 import { Inject, Injectable } from '@nestjs/common'
 import { PassportStrategy } from '@nestjs/passport'
 import { passportJwtSecret } from 'jwks-rsa'
@@ -6,10 +5,15 @@ import { ExtractJwt, Strategy } from 'passport-jwt'
 import { GetUserService } from '../../use-cases/get-user'
 import { UpsertUserService } from '../../use-cases/upsert-user'
 import { Auth0Config, auth0Config } from '../auth0'
-import { JWT_CLAIMS, JwtPayload } from './jwt.interface'
+import { JwtPayload } from './jwt.interface'
+
+export const jwtLocalStrategyName = 'jwt_local'
 
 @Injectable()
-export class JwtStrategy extends PassportStrategy(Strategy) {
+export class JwtLocalStrategy extends PassportStrategy(
+  Strategy,
+  jwtLocalStrategyName,
+) {
   constructor(
     @Inject(auth0Config.KEY) readonly _auth0Config: Auth0Config,
     private getUserService: GetUserService,
@@ -21,7 +25,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         rateLimit: true,
         jwksRequestsPerMinute: 5,
         // Use the URL helper class, because it's better than relying on the issuer url to not have a trailing /
-        jwksUri: new URL('.well-known/jwks.json', _auth0Config.issuer).href,
+        jwksUri: new URL('.well-known/jwks.json', _auth0Config.local.issuer)
+          .href,
         handleSigningKeyError: (err) => console.error(err), // do it better in real app!
       }),
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -32,42 +37,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     })
   }
 
-  /**
-   * At this point, Auth0 has already checked the validity of the JWT token, we can do further validation to check for roles or permissions here.
-   *
-   * We search the database to see whether the user exists, otherwise we create it
-   *
-   * @param payload
-   * @returns
-   */
-  protected async validate(payload: JwtPayload): Promise<IUser> {
-    const user = await this.getUserService.execute({ auth0Id: payload.sub })
-
-    const roles = payload[JWT_CLAIMS].roles.length
-      ? payload[JWT_CLAIMS].roles
-      : [Role.User]
-
-    let userId
-
-    if (user) {
-      userId = user.id
-    } else {
-      const { id } = await this.upsertUserService.execute({
-        input: {
-          data: {
-            auth0Id: payload.sub,
-            roles,
-          },
-        },
-      })
-
-      userId = id
-    }
-
-    return {
-      id: userId,
-      auth0Id: payload.sub,
-      roles,
-    }
+  // do nothing with local jwt for now
+  protected async validate(payload: JwtPayload): Promise<any> {
+    return {}
   }
 }

--- a/libs/backend/modules/user/src/infra/auth0/config/auth0.config.ts
+++ b/libs/backend/modules/user/src/infra/auth0/config/auth0.config.ts
@@ -19,6 +19,10 @@ export interface Auth0Config {
     clientId: string
     clientSecret: string
   }
+  local: {
+    issuer: string
+    audience: string
+  }
   // admin: UsernamePassword
   cypress: UsernamePassword
 }
@@ -33,6 +37,10 @@ export const auth0Config = registerAs<Auth0Config>(
     clientId: get('AUTH0_CLIENT_ID').required().asString(),
     clientSecret: get('AUTH0_CLIENT_SECRET').required().asString(),
     audience: get('AUTH0_AUDIENCE').required().asString(),
+    local: {
+      issuer: get('LOCAL_AUTH0_ISSUER_BASE_URL').required().asUrlString(),
+      audience: get('LOCAL_AUTH0_AUDIENCE').required().asString(),
+    },
     api: {
       // audience: get('AUTH0_AUDIENCE').required().asString(),
       clientId: get('AUTH0_API_CLIENT_ID').required().asString(),

--- a/libs/frontend/model/infra/api/src/GraphqlOperationOptions.ts
+++ b/libs/frontend/model/infra/api/src/GraphqlOperationOptions.ts
@@ -1,8 +1,14 @@
 import { Nullable } from '@codelab/shared/abstract/types'
 import type { RequestInit } from 'graphql-request/dist/types.dom'
 
+export enum API_ENV {
+  production = 'production',
+  local = 'local',
+}
+
 export interface GraphqlOperationOptions<
   TVariables extends Record<string, any> = Record<string, any>,
 > extends Pick<RequestInit, 'headers'> {
   variables?: Nullable<TVariables>
+  env?: API_ENV
 }

--- a/libs/frontend/model/infra/api/src/client.ts
+++ b/libs/frontend/model/infra/api/src/client.ts
@@ -1,14 +1,34 @@
 import { Maybe, Nullable } from '@codelab/shared/abstract/types'
 import { GraphQLClient } from 'graphql-request'
 import type { RequestInit } from 'graphql-request/dist/types.dom'
+import { API_ENV } from './GraphqlOperationOptions'
 
-const API_URL = `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/graphql`
-let client: Maybe<GraphQLClient>
+const apiUrlsByEnv: Record<API_ENV, string> = {
+  local: `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/graphql`,
+  production: `${process.env.NEXT_PUBLIC_PRODUCTION_API_ORIGIN}/api/graphql`,
+}
 
-export const getGraphQLClient = (options?: Nullable<RequestInit>) => {
-  if (!client) {
-    client = new GraphQLClient(API_URL, options ?? undefined)
+let localGraphqlClient: Maybe<GraphQLClient>
+let productionGraphqlClient: Maybe<GraphQLClient>
+
+export const getGraphQLClient = (
+  options?: Nullable<RequestInit & { env?: API_ENV }>,
+) => {
+  const apiEnv = options?.env || API_ENV.local
+  const apiUrl = apiUrlsByEnv[apiEnv]
+
+  if (apiEnv === API_ENV.local) {
+    if (!localGraphqlClient) {
+      localGraphqlClient = new GraphQLClient(apiUrl, options ?? undefined)
+    }
+
+    return localGraphqlClient
   }
 
-  return client
+  // production graphql client
+  if (!productionGraphqlClient) {
+    productionGraphqlClient = new GraphQLClient(apiUrl, options ?? undefined)
+  }
+
+  return productionGraphqlClient
 }

--- a/libs/frontend/model/infra/api/src/client.ts
+++ b/libs/frontend/model/infra/api/src/client.ts
@@ -5,7 +5,7 @@ import { API_ENV } from './GraphqlOperationOptions'
 
 const apiUrlsByEnv: Record<API_ENV, string> = {
   local: `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/graphql`,
-  production: `${process.env.NEXT_PUBLIC_PRODUCTION_API_ORIGIN}/api/graphql`,
+  production: `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/prod/graphql`,
 }
 
 let localGraphqlClient: Maybe<GraphQLClient>

--- a/libs/frontend/modules/admin/src/use-cases/index.ts
+++ b/libs/frontend/modules/admin/src/use-cases/index.ts
@@ -1,2 +1,3 @@
 export * from './reset-data'
 export * from './seed-base-types'
+export * from './sync-atoms'

--- a/libs/frontend/modules/admin/src/use-cases/sync-atoms/SyncAtoms.tsx
+++ b/libs/frontend/modules/admin/src/use-cases/sync-atoms/SyncAtoms.tsx
@@ -1,0 +1,53 @@
+import { API_ENV } from '@codelab/frontend/model/infra/api'
+import {
+  useImportAtomsMutation,
+  useLazyExportAtomsQuery,
+} from '@codelab/frontend/modules/atom'
+import { notify, useNotify } from '@codelab/frontend/shared/utils'
+import { Button } from 'antd'
+
+const hardCodedAtomIds = ['0x551ac']
+
+export const SyncAtoms = () => {
+  const [getExportAtoms, { isLoading: isLoadingDownAtoms }] =
+    useLazyExportAtomsQuery()
+
+  const [importAtom, { isLoading: isLoadingImportAtoms }] =
+    useImportAtomsMutation()
+
+  const { onSuccess, onError } = useNotify(
+    { title: 'Atoms has been synced successfully' },
+    { title: 'Failed to sync atoms' },
+  )
+
+  const onClick = async () => {
+    let atomData
+
+    try {
+      atomData = await getExportAtoms({
+        env: API_ENV.production,
+        variables: { input: { where: { ids: hardCodedAtomIds } } },
+      }).unwrap()
+    } catch {
+      notify({ title: 'Failed to down atoms', type: 'error' })
+
+      return
+    }
+
+    // try {
+    //   await importAtom({ variables: { input: { payload: JSON.stringify(atomData.data.getAtoms) } } }).unwrap()
+    //   onSuccess()
+    // } catch {
+    //   onError()
+    // }
+  }
+
+  return (
+    <Button
+      loading={isLoadingDownAtoms || isLoadingImportAtoms}
+      onClick={onClick}
+    >
+      Sync Atoms
+    </Button>
+  )
+}

--- a/libs/frontend/modules/admin/src/use-cases/sync-atoms/index.ts
+++ b/libs/frontend/modules/admin/src/use-cases/sync-atoms/index.ts
@@ -1,0 +1,1 @@
+export * from './SyncAtoms'


### PR DESCRIPTION
CLOSES: #1254


## Expected Behavior
- Add button `Sync Atoms` in admin page
- This button will down atom data of hardcoded atom ids using query `getAtoms`, and import them to user account using mutation `importAtoms`
- Implement proxy `prod/graphql` to proxy to production graphql endpoint using dev/local token (this would save us some trouble when implementing best practice authenticate like nextjs/auth0)
- query `getAtoms` allows local jwt token to access 

<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1254
