### PR TITLE
feat: app import-export

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -296,6 +296,16 @@
               //   ]
               // },
               {
+                "sourceTag": "scope:cli",
+                "onlyDependOnLibsWithTags": [
+                  "scope:frontend",
+                  "scope:codegen",
+                  "scope:backend",
+                  "scope:shared",
+                  "type:abstract"
+                ]
+              },
+              {
                 "sourceTag": "scope:e2e",
                 "onlyDependOnLibsWithTags": [
                   "scope:frontend",

--- a/apps/cli/custom.d.ts
+++ b/apps/cli/custom.d.ts
@@ -1,0 +1,16 @@
+declare module '*.svg' {
+  const content: any
+
+  export const ReactComponent: any
+  export default content
+}
+
+declare module '*.cypher' {
+  const content: string
+  export default content
+}
+
+interface Window {
+  jQuery: JQueryStatic
+  Morphtext: any
+}

--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -10,7 +10,8 @@
         "outputPath": "dist/apps/cli",
         "main": "apps/cli/src/main.ts",
         "tsConfig": "apps/cli/tsconfig.app.json",
-        "assets": ["apps/cli/src/assets"]
+        "assets": ["apps/cli/src/assets"],
+        "webpackConfig": ["apps/cli/webpack.config.js"]
       },
       "configurations": {
         "production": {
@@ -40,5 +41,5 @@
       }
     }
   },
-  "tags": []
+  "tags": ["scope:cli"]
 }

--- a/apps/cli/src/commands/export/export-app.command.ts
+++ b/apps/cli/src/commands/export/export-app.command.ts
@@ -1,0 +1,139 @@
+import {
+  App as IAppModel,
+  AppModel,
+  ComponentModel,
+  componentSelectionSet,
+  elementGraph,
+  ElementModel,
+  elementSelectionSet,
+  Page as IPageModel,
+  PageModel,
+  pageSelectionSet,
+} from '@codelab/backend'
+import { config } from 'dotenv'
+import fs from 'fs'
+import * as inquirer from 'inquirer'
+import { flatMap, flatten } from 'lodash'
+import yargs, { CommandModule } from 'yargs'
+
+const appSelectionSet = `{ id, name, rootProviderElement { id } }`
+
+export const exportAppCommand: CommandModule<any, any> = {
+  command: 'export-app',
+
+  handler: async () => {
+    config({ path: `${process.cwd()}/.env` })
+
+    const Apps = await AppModel()
+
+    const apps: Array<IAppModel> = await Apps.find({
+      selectionSet: appSelectionSet,
+    })
+
+    const selection = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'app',
+        message: 'Select app to export',
+        choices: apps.map((app) => ({
+          name: app.name,
+          value: app.id,
+        })),
+      },
+    ])
+
+    const app = apps.find((a) => a.id === selection.app)
+
+    if (!app) {
+      throw new Error('App not found')
+    }
+
+    const { outputPath } = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'outputPath',
+        message: 'Enter a path to export to',
+        default: `${app.name ?? 'app'}.json`,
+      },
+    ])
+
+    if (!outputPath.endsWith('.json')) {
+      throw new Error('Output path must end with .json')
+    }
+
+    const data = await getAppData(app)
+    const json = JSON.stringify(data, null, 2)
+
+    fs.writeFileSync(outputPath, json)
+
+    yargs.exit(0, null!)
+  },
+}
+
+const getAppData = async (app: IAppModel) => {
+  // gather all pages, elements and components
+
+  const Pages = await PageModel()
+
+  const pages = await Pages.find({
+    where: { app: { id: app.id } },
+    selectionSet: pageSelectionSet,
+  })
+
+  const pagesData = await Promise.all(
+    pages.map(async (page) => {
+      const { elements, components } = await getPageData(page)
+
+      return { page, elements, components }
+    }),
+  )
+
+  const providerElements = await getElementAndDescendants(
+    app.rootProviderElement.id,
+  )
+
+  return { app, pages: pagesData, providerElements }
+}
+
+const getPageData = async (page: IPageModel) => {
+  const Components = await ComponentModel()
+  const elements = await getElementAndDescendants(page.rootElement.id)
+
+  const componentIds = flatMap(elements, (e) => [
+    e.component?.id,
+    e.instanceOfComponent?.id,
+  ]).filter(Boolean) as Array<string>
+
+  const components = await Components.find({
+    where: { id_IN: componentIds },
+    selectionSet: componentSelectionSet,
+  })
+
+  const componentRootIds = components.map((c) => c.rootElement.id)
+
+  const componentElements = await Promise.all(
+    componentRootIds.map((id) => getElementAndDescendants(id)),
+  )
+
+  return {
+    elements: [...elements, ...flatten(componentElements)],
+    components,
+  }
+}
+
+const getElementAndDescendants = async (rootId: string) => {
+  const { id, descendants } = await elementGraph(
+    null,
+    { input: { rootId } },
+    null,
+    null as any,
+  )
+
+  const elementIds = [id, ...descendants]
+  const Elements = await ElementModel()
+
+  return await Elements.find({
+    where: { id_IN: elementIds },
+    selectionSet: elementSelectionSet,
+  })
+}

--- a/apps/cli/src/commands/export/export-app.ts
+++ b/apps/cli/src/commands/export/export-app.ts
@@ -1,0 +1,29 @@
+import { App as IAppModel, PageModel, pageSelectionSet } from '@codelab/backend'
+import { getElementAndDescendants } from './export-element'
+import { getPageData } from './export-page'
+
+/**
+ * Gather all pages, elements and components
+ */
+export const getAppData = async (app: IAppModel) => {
+  const Page = await PageModel()
+
+  const pages = await Page.find({
+    where: { app: { id: app.id } },
+    selectionSet: pageSelectionSet,
+  })
+
+  const pagesData = await Promise.all(
+    pages.map(async (page) => {
+      const { elements, components } = await getPageData(page)
+
+      return { page, elements, components }
+    }),
+  )
+
+  const providerElements = await getElementAndDescendants(
+    app.rootProviderElement.id,
+  )
+
+  return { app, pages: pagesData, providerElements }
+}

--- a/apps/cli/src/commands/export/export-element.ts
+++ b/apps/cli/src/commands/export/export-element.ts
@@ -1,0 +1,22 @@
+import {
+  elementGraph,
+  ElementModel,
+  elementSelectionSet,
+} from '@codelab/backend'
+
+export const getElementAndDescendants = async (rootId: string) => {
+  const { id, descendants } = await elementGraph(
+    null,
+    { input: { rootId } },
+    null,
+    null as any,
+  )
+
+  const elementIds = [id, ...descendants]
+  const Elements = await ElementModel()
+
+  return await Elements.find({
+    where: { id_IN: elementIds },
+    selectionSet: elementSelectionSet,
+  })
+}

--- a/apps/cli/src/commands/export/export-page.ts
+++ b/apps/cli/src/commands/export/export-page.ts
@@ -1,0 +1,33 @@
+import {
+  ComponentModel,
+  componentSelectionSet,
+  Page as IPageModel,
+} from '@codelab/backend'
+import { flatMap, flatten } from 'lodash'
+import { getElementAndDescendants } from './export-element'
+
+export const getPageData = async (page: IPageModel) => {
+  const Component = await ComponentModel()
+  const elements = await getElementAndDescendants(page.rootElement.id)
+
+  const componentIds = flatMap(elements, (e) => [
+    e.component?.id,
+    e.instanceOfComponent?.id,
+  ]).filter(Boolean) as Array<string>
+
+  const components = await Component.find({
+    where: { id_IN: componentIds },
+    selectionSet: componentSelectionSet,
+  })
+
+  const componentRootIds = components.map((c) => c.rootElement.id)
+
+  const componentElements = await Promise.all(
+    componentRootIds.map((id) => getElementAndDescendants(id)),
+  )
+
+  return {
+    elements: [...elements, ...flatten(componentElements)],
+    components,
+  }
+}

--- a/apps/cli/src/commands/export/import-app.command.ts
+++ b/apps/cli/src/commands/export/import-app.command.ts
@@ -1,0 +1,267 @@
+import {
+  App as IAppModel,
+  AppModel,
+  Atom as IAtomModel,
+  AtomModel,
+  Component as IComponentModel,
+  ComponentModel,
+  Element as IElementModel,
+  ElementModel,
+  Page as IPageModel,
+  UserModel,
+} from '@codelab/backend'
+import { config } from 'dotenv'
+import fs from 'fs'
+import * as inquirer from 'inquirer'
+import { flatMap } from 'lodash'
+import yargs, { CommandModule } from 'yargs'
+
+interface PagePack {
+  page: IPageModel
+  components: Array<IComponentModel>
+  elements: Array<IElementModel>
+}
+
+export const importAppCommand: CommandModule<any, any> = {
+  command: 'import-app <filePath>',
+  handler: async ({ filePath }) => {
+    config({ path: `${process.cwd()}/.env` })
+
+    const json = fs.readFileSync(filePath, 'utf8')
+    const Apps = await AppModel()
+    const Users = await UserModel()
+    const allUsers = await Users.find()
+
+    const { selectedUser } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'selectedUser',
+        message: 'Select which user to be owner of the app',
+        choices: allUsers.map((user) => ({
+          name: user.email,
+          value: user.id,
+        })),
+      },
+    ])
+
+    const { pages, app, providerElements } = JSON.parse(json) as {
+      app: IAppModel
+      pages: Array<PagePack>
+      providerElements: Array<IElementModel>
+    }
+
+    await validate(pages)
+
+    const idMap = new Map<string, string>()
+
+    for (const element of providerElements) {
+      const newElement = await importElementInitial(element, idMap)
+
+      idMap.set(element.id, newElement.id)
+    }
+
+    for (const element of providerElements) {
+      await updateImportedElement(element, idMap)
+    }
+
+    for (const { elements, components } of pages) {
+      for (const component of components) {
+        const newComponent = await importComponent(component, selectedUser)
+
+        idMap.set(component.id, newComponent.id)
+      }
+
+      for (const element of elements) {
+        const newElement = await importElementInitial(element, idMap)
+
+        idMap.set(element.id, newElement.id)
+      }
+
+      for (const element of elements) {
+        await updateImportedElement(element, idMap)
+      }
+    }
+
+    const {
+      apps: [importedApp],
+    } = await Apps.create({
+      input: [
+        {
+          name: `${app.name} - Imported at ${new Date().toISOString()}`,
+          owner: { connect: { where: { node: { id: selectedUser } } } as any },
+          rootProviderElement: {
+            connect: {
+              where: { node: { id: idMap.get(app.rootProviderElement.id) } },
+            } as any,
+          },
+          pages: {
+            create: pages.map(({ page }) => ({
+              node: {
+                name: page.name,
+                rootElement: {
+                  connect: {
+                    where: { node: { id: idMap.get(page.rootElement.id) } },
+                  },
+                },
+              },
+            })),
+          },
+        },
+      ],
+    })
+
+    console.log(`Imported app with id ${importedApp.id}`)
+    yargs.exit(0, null!)
+  },
+}
+
+const validate = async (pages: Array<PagePack>) => {
+  const Atoms = await AtomModel()
+
+  let allAtomIds = flatMap(
+    pages,
+    (page) =>
+      page.elements.map((e) => e.atom?.id).filter(Boolean) as Array<string>,
+  )
+
+  allAtomIds = [...new Set(allAtomIds)]
+
+  const foundAtoms = await Atoms.find({
+    where: { id_IN: allAtomIds },
+  })
+
+  const foundAtomsMap = new Map<string, IAtomModel>(
+    foundAtoms.map((f) => [f.id, f]),
+  )
+
+  const notFound = allAtomIds.filter((id) => !foundAtomsMap.has(id))
+
+  if (notFound.length) {
+    throw new Error(`Can't find Atoms with ids "${notFound.join(', ')}"`)
+  }
+}
+
+// Creates the element without prop map bindings and without parent/children connections
+const importElementInitial = async (
+  element: IElementModel,
+  idMap: Map<string, string>,
+): Promise<IElementModel> => {
+  const Elements = await ElementModel()
+
+  const {
+    elements: [newElement],
+  } = await Elements.create({
+    input: [
+      {
+        name: element.name,
+        css: element.css,
+        atom: element.atom
+          ? { connect: { where: { node: { id: element.atom.id } } } }
+          : undefined,
+        component: element.component
+          ? {
+              connect: {
+                where: { node: { id: idMap.get(element.component.id) } },
+              },
+            }
+          : undefined,
+        instanceOfComponent: element.instanceOfComponent
+          ? {
+              connect: {
+                where: { node: { id: element.instanceOfComponent.id } },
+              },
+            }
+          : undefined,
+        props: element.props
+          ? {
+              create: { node: { data: element.props.data } },
+            }
+          : undefined,
+        propTransformationJs: element.propTransformationJs,
+        renderForEachPropKey: element.renderForEachPropKey,
+        renderIfPropKey: element.renderIfPropKey,
+      },
+    ],
+  })
+
+  return newElement
+}
+
+// Updates the imported element with prop map bindings, parent/children connections and props after we have
+// imported all the elements, so we can reference them
+const updateImportedElement = async (
+  element: IElementModel,
+  idMap: Map<string, string>,
+): Promise<void> => {
+  const Elements = await ElementModel()
+
+  if (element.props) {
+    // replace all references in props
+    for (const [key, value] of idMap.entries()) {
+      element.props.data = element.props.data.replace(
+        new RegExp(key, 'g'),
+        value,
+      )
+    }
+  }
+
+  await Elements.update({
+    where: { id: idMap.get(element.id) },
+    update: {
+      parentElement: element.parentElement
+        ? {
+            disconnect: { where: {} },
+            connect: {
+              edge: { order: element.parentElementConnection?.edges[0].order },
+              where: { node: { id: idMap.get(element.parentElement.id) } },
+            },
+          }
+        : undefined,
+      props: element.props
+        ? {
+            update: { node: { data: element.props.data } },
+          }
+        : undefined,
+      propMapBindings: element.propMapBindings.map((pmb) => ({
+        create: [
+          {
+            node: {
+              sourceKey: pmb.sourceKey,
+              targetKey: pmb.targetKey,
+              targetElement: pmb.targetElement
+                ? {
+                    connect: {
+                      where: {
+                        node: { id: idMap.get(pmb.targetElement.id) },
+                      },
+                    },
+                  }
+                : undefined,
+            },
+          },
+        ],
+      })),
+    },
+  })
+}
+
+const importComponent = async (
+  component: IComponentModel,
+  selectedUser: string,
+): Promise<IComponentModel> => {
+  const Components = await ComponentModel()
+
+  const {
+    components: [newComponent],
+  } = await Components.create({
+    input: [
+      {
+        name: component.name,
+        owner: { connect: { where: { node: { id: selectedUser } } } },
+        rootElement: { create: { node: { name: '' } } },
+      },
+    ],
+  })
+
+  return newComponent
+}

--- a/apps/cli/src/commands/import/import-app.command.ts
+++ b/apps/cli/src/commands/import/import-app.command.ts
@@ -4,9 +4,7 @@ import {
   Atom as IAtomModel,
   AtomModel,
   Component as IComponentModel,
-  ComponentModel,
   Element as IElementModel,
-  ElementModel,
   Page as IPageModel,
   UserModel,
 } from '@codelab/backend'
@@ -14,7 +12,10 @@ import { config } from 'dotenv'
 import fs from 'fs'
 import * as inquirer from 'inquirer'
 import { flatMap } from 'lodash'
+import path from 'path'
 import yargs, { CommandModule } from 'yargs'
+import { importComponent } from './import-component'
+import { importElementInitial, updateImportedElement } from './import-element'
 
 interface PagePack {
   page: IPageModel
@@ -27,7 +28,7 @@ export const importAppCommand: CommandModule<any, any> = {
   handler: async ({ filePath }) => {
     config({ path: `${process.cwd()}/.env` })
 
-    const json = fs.readFileSync(filePath, 'utf8')
+    const json = fs.readFileSync(path.resolve('data', filePath), 'utf8')
     const Apps = await AppModel()
     const Users = await UserModel()
     const allUsers = await Users.find()
@@ -139,129 +140,4 @@ const validate = async (pages: Array<PagePack>) => {
   if (notFound.length) {
     throw new Error(`Can't find Atoms with ids "${notFound.join(', ')}"`)
   }
-}
-
-// Creates the element without prop map bindings and without parent/children connections
-const importElementInitial = async (
-  element: IElementModel,
-  idMap: Map<string, string>,
-): Promise<IElementModel> => {
-  const Elements = await ElementModel()
-
-  const {
-    elements: [newElement],
-  } = await Elements.create({
-    input: [
-      {
-        name: element.name,
-        css: element.css,
-        atom: element.atom
-          ? { connect: { where: { node: { id: element.atom.id } } } }
-          : undefined,
-        component: element.component
-          ? {
-              connect: {
-                where: { node: { id: idMap.get(element.component.id) } },
-              },
-            }
-          : undefined,
-        instanceOfComponent: element.instanceOfComponent
-          ? {
-              connect: {
-                where: { node: { id: element.instanceOfComponent.id } },
-              },
-            }
-          : undefined,
-        props: element.props
-          ? {
-              create: { node: { data: element.props.data } },
-            }
-          : undefined,
-        propTransformationJs: element.propTransformationJs,
-        renderForEachPropKey: element.renderForEachPropKey,
-        renderIfPropKey: element.renderIfPropKey,
-      },
-    ],
-  })
-
-  return newElement
-}
-
-// Updates the imported element with prop map bindings, parent/children connections and props after we have
-// imported all the elements, so we can reference them
-const updateImportedElement = async (
-  element: IElementModel,
-  idMap: Map<string, string>,
-): Promise<void> => {
-  const Elements = await ElementModel()
-
-  if (element.props) {
-    // replace all references in props
-    for (const [key, value] of idMap.entries()) {
-      element.props.data = element.props.data.replace(
-        new RegExp(key, 'g'),
-        value,
-      )
-    }
-  }
-
-  await Elements.update({
-    where: { id: idMap.get(element.id) },
-    update: {
-      parentElement: element.parentElement
-        ? {
-            disconnect: { where: {} },
-            connect: {
-              edge: { order: element.parentElementConnection?.edges[0].order },
-              where: { node: { id: idMap.get(element.parentElement.id) } },
-            },
-          }
-        : undefined,
-      props: element.props
-        ? {
-            update: { node: { data: element.props.data } },
-          }
-        : undefined,
-      propMapBindings: element.propMapBindings.map((pmb) => ({
-        create: [
-          {
-            node: {
-              sourceKey: pmb.sourceKey,
-              targetKey: pmb.targetKey,
-              targetElement: pmb.targetElement
-                ? {
-                    connect: {
-                      where: {
-                        node: { id: idMap.get(pmb.targetElement.id) },
-                      },
-                    },
-                  }
-                : undefined,
-            },
-          },
-        ],
-      })),
-    },
-  })
-}
-
-const importComponent = async (
-  component: IComponentModel,
-  selectedUser: string,
-): Promise<IComponentModel> => {
-  const Components = await ComponentModel()
-
-  const {
-    components: [newComponent],
-  } = await Components.create({
-    input: [
-      {
-        name: component.name,
-        owner: { connect: { where: { node: { id: selectedUser } } } },
-        rootElement: { create: { node: { name: '' } } },
-      },
-    ],
-  })
-
-  return newComponent
 }

--- a/apps/cli/src/commands/import/import-component.ts
+++ b/apps/cli/src/commands/import/import-component.ts
@@ -1,0 +1,22 @@
+import { Component as IComponentModel, ComponentModel } from '@codelab/backend'
+
+export const importComponent = async (
+  component: IComponentModel,
+  selectedUser: string,
+): Promise<IComponentModel> => {
+  const Components = await ComponentModel()
+
+  const {
+    components: [newComponent],
+  } = await Components.create({
+    input: [
+      {
+        name: component.name,
+        owner: { connect: { where: { node: { id: selectedUser } } } },
+        rootElement: { create: { node: { name: '' } } },
+      },
+    ],
+  })
+
+  return newComponent
+}

--- a/apps/cli/src/commands/import/import-element.ts
+++ b/apps/cli/src/commands/import/import-element.ts
@@ -1,0 +1,108 @@
+import { Element as IElementModel, ElementModel } from '@codelab/backend'
+
+/**
+ * Creates the element without prop map bindings and without parent/children connections
+ */
+export const importElementInitial = async (
+  element: IElementModel,
+  idMap: Map<string, string>,
+): Promise<IElementModel> => {
+  const Elements = await ElementModel()
+
+  const {
+    elements: [newElement],
+  } = await Elements.create({
+    input: [
+      {
+        name: element.name,
+        css: element.css,
+        atom: element.atom
+          ? { connect: { where: { node: { id: element.atom.id } } } }
+          : undefined,
+        component: element.component
+          ? {
+              connect: {
+                where: { node: { id: idMap.get(element.component.id) } },
+              },
+            }
+          : undefined,
+        instanceOfComponent: element.instanceOfComponent
+          ? {
+              connect: {
+                where: { node: { id: element.instanceOfComponent.id } },
+              },
+            }
+          : undefined,
+        props: element.props
+          ? {
+              create: { node: { data: element.props.data } },
+            }
+          : undefined,
+        propTransformationJs: element.propTransformationJs,
+        renderForEachPropKey: element.renderForEachPropKey,
+        renderIfPropKey: element.renderIfPropKey,
+      },
+    ],
+  })
+
+  return newElement
+}
+
+/**
+ * Updates the imported element with prop map bindings, parent/children connections and props after we have imported all the elements, so we can reference them
+ */
+export const updateImportedElement = async (
+  element: IElementModel,
+  idMap: Map<string, string>,
+): Promise<void> => {
+  const Elements = await ElementModel()
+
+  if (element.props) {
+    // replace all references in props
+    for (const [key, value] of idMap.entries()) {
+      element.props.data = element.props.data.replace(
+        new RegExp(key, 'g'),
+        value,
+      )
+    }
+  }
+
+  await Elements.update({
+    where: { id: idMap.get(element.id) },
+    update: {
+      parentElement: element.parentElement
+        ? {
+            disconnect: { where: {} },
+            connect: {
+              edge: { order: element.parentElementConnection?.edges[0].order },
+              where: { node: { id: idMap.get(element.parentElement.id) } },
+            },
+          }
+        : undefined,
+      props: element.props
+        ? {
+            update: { node: { data: element.props.data } },
+          }
+        : undefined,
+      propMapBindings: element.propMapBindings.map((pmb) => ({
+        create: [
+          {
+            node: {
+              sourceKey: pmb.sourceKey,
+              targetKey: pmb.targetKey,
+              targetElement: pmb.targetElement
+                ? {
+                    connect: {
+                      where: {
+                        node: { id: idMap.get(pmb.targetElement.id) },
+                      },
+                    },
+                  }
+                : undefined,
+            },
+          },
+        ],
+      })),
+    },
+  })
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -5,7 +5,7 @@
 import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 import { exportAppCommand } from './commands/export/export-app.command'
-import { importAppCommand } from './commands/export/import-app.command'
+import { importAppCommand } from './commands/import/import-app.command'
 import { Env } from './utils/env'
 import { requireEnvOptions, requireTestEnvOptions } from './utils/options'
 import { runCli } from './utils/run-cli'

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -4,6 +4,8 @@
  */
 import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
+import { exportAppCommand } from './commands/export/export-app.command'
+import { importAppCommand } from './commands/export/import-app.command'
 import { Env } from './utils/env'
 import { requireEnvOptions, requireTestEnvOptions } from './utils/options'
 import { runCli } from './utils/run-cli'
@@ -124,4 +126,9 @@ yargs(hideBin(process.argv))
       (argv) => runCli(Env.Dev, `parse-ts mui -d ${argv.dir}`),
     )
   })
+  //
+  // Export/import app
+  //
+  .command(exportAppCommand)
+  .command(importAppCommand)
   .demandCommand(1, 'Please provide a command').argv

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -3,11 +3,23 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["node"],
     "esModuleInterop": true,
     "strict": true,
+    "types": ["node", "worker-loader", "window", "@fancyapps/ui", "cypher"],
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "jsx": "preserve",
+    "allowJs": true,
+    "jsxImportSource": "@emotion/react",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true,
+    "useDefineForClassFields": true
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "files": [],
-  "include": [],
+  "include": ["**/*.ts", "**/*.tsx", "custom.d.ts", "**/*.js", "**/*.jsx"],
   "references": [
     {
       "path": "./tsconfig.app.json"

--- a/apps/cli/webpack.config.js
+++ b/apps/cli/webpack.config.js
@@ -1,0 +1,15 @@
+// Helper for combining webpack config objects
+const { merge } = require('webpack-merge')
+
+module.exports = (config, context) => {
+  return merge(config, {
+    module: {
+      rules: [
+        {
+          test: /\.(cypher|cyp)$/,
+          type: 'asset/source',
+        },
+      ],
+    },
+  })
+}

--- a/apps/web/pages/apps/[appId]/pages/[pageId]/builder.tsx
+++ b/apps/web/pages/apps/[appId]/pages/[pageId]/builder.tsx
@@ -125,6 +125,7 @@ PageBuilder.Layout = observer((page) => {
         ))}
         builderService={store.builderService}
         headerHeight={38}
+        key={store.builderService.builderRenderer.tree?.id}
       >
         {page.children}
       </BuilderDashboardTemplate>

--- a/data/Codelab.json
+++ b/data/Codelab.json
@@ -1,0 +1,62 @@
+{
+  "app": {
+    "id": "cfba7669-6582-467e-8952-595cdafb241f",
+    "name": "Codelab",
+    "rootProviderElement": {
+      "id": "24ee5f15-8989-4af9-b526-d5c7d9b9f92f"
+    }
+  },
+  "pages": [
+    {
+      "page": {
+        "id": "f24aad1b-c276-4aa2-9bbd-3d5e76d0009b",
+        "name": "Home",
+        "rootElement": {
+          "id": "6dc57b70-b70d-41c1-9522-07ff444b73c7",
+          "name": "Root element"
+        }
+      },
+      "elements": [
+        {
+          "id": "6dc57b70-b70d-41c1-9522-07ff444b73c7",
+          "name": "Root element",
+          "css": null,
+          "component": null,
+          "instanceOfComponent": null,
+          "parentElement": null,
+          "atom": null,
+          "props": null,
+          "hooks": [],
+          "renderForEachPropKey": null,
+          "renderIfPropKey": null,
+          "propMapBindings": [],
+          "propTransformationJs": null,
+          "parentElementConnection": {
+            "edges": []
+          }
+        }
+      ],
+      "components": []
+    }
+  ],
+  "providerElements": [
+    {
+      "id": "24ee5f15-8989-4af9-b526-d5c7d9b9f92f",
+      "name": "Provider Root Element",
+      "css": null,
+      "component": null,
+      "instanceOfComponent": null,
+      "parentElement": null,
+      "atom": null,
+      "props": null,
+      "hooks": [],
+      "renderForEachPropKey": null,
+      "renderIfPropKey": null,
+      "propMapBindings": [],
+      "propTransformationJs": null,
+      "parentElementConnection": {
+        "edges": []
+      }
+    }
+  ]
+}

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -1,4 +1,7 @@
 export * from './generate-ogm-types'
 export * from './infra'
 export * from './model'
+export type { App, Atom, Component, Element, Page } from './ogm-types.gen'
+export * from './resolvers'
 export * from './schema'
+export * from './selectionSets'

--- a/libs/backend/src/infra/driver.ts
+++ b/libs/backend/src/infra/driver.ts
@@ -1,17 +1,17 @@
 import { Config } from '@codelab/shared/utils'
 import neo4j, { Driver } from 'neo4j-driver'
 
-const defaultOptions = {
+const defaultOptions = () => ({
   uri: Config().neo4j.uri,
   username: Config().neo4j.user,
   password: Config().neo4j.password,
-}
+})
 
 // Keep a single driver instance if possible
 let driver: Driver
 
 export const getDriver = () => {
-  const { uri, username, password } = defaultOptions
+  const { uri, username, password } = defaultOptions()
 
   return (driver ??= neo4j.driver(uri, neo4j.auth.basic(username, password)))
 }

--- a/libs/backend/src/model.ts
+++ b/libs/backend/src/model.ts
@@ -1,5 +1,6 @@
 import { getOgm } from './infra/ogm'
 import {
+  AppModel as IAppModel,
   AppTypeModel as IAppTypeModel,
   ArrayTypeModel as IArrayTypeModel,
   AtomModel as IAtomModel,
@@ -27,13 +28,18 @@ let userInst: IUserModel
 export const UserModel = async () =>
   (userInst ??= (await getOgm()).model('User'))
 
+let appInst: IAppModel
+
+export const AppModel = async () => (appInst ??= (await getOgm()).model('App'))
+
 let atomInst: IAtomModel
 
-export const Atom = async () => (atomInst ??= (await getOgm()).model('Atom'))
+export const AtomModel = async () =>
+  (atomInst ??= (await getOgm()).model('Atom'))
 
 let elementInst: IElementModel
 
-export const Element = async () =>
+export const ElementModel = async () =>
   (elementInst ??= (await getOgm()).model('Element'))
 
 let storeInst: IStoreModel
@@ -84,10 +90,10 @@ let LambdaInst: ILambdaTypeModel
 export const LambdaTypeModel = async () =>
   (LambdaInst ??= (await getOgm()).model('LambdaType'))
 
-let appInst: IAppTypeModel
+let appTypeInst: IAppTypeModel
 
 export const AppTypeModel = async () =>
-  (appInst ??= (await getOgm()).model('AppType'))
+  (appTypeInst ??= (await getOgm()).model('AppType'))
 
 let renderPropsInst: IRenderPropsTypeModel
 

--- a/libs/backend/src/repositories/atom/atom.repository.ts
+++ b/libs/backend/src/repositories/atom/atom.repository.ts
@@ -1,0 +1,66 @@
+import { IAtomDTO } from '@codelab/shared/abstract/core'
+import { Maybe } from '@codelab/shared/abstract/types'
+import { RxTransaction } from 'neo4j-driver'
+import { Observable } from 'rxjs'
+import { first, map } from 'rxjs/operators'
+import { v4 } from 'uuid'
+import { AtomModel } from '../../model'
+import {
+  Atom as AtomInput,
+  AtomCreateInput,
+  AtomTagsConnectFieldInput,
+  CreateAtomsMutationResponse,
+  Tag,
+} from '../../ogm-types.gen'
+import exportAtom from './exportAtom.cypher'
+
+export const atomRepository = {
+  exportAtom: (txn: RxTransaction): Observable<Maybe<Array<IAtomDTO>>> =>
+    txn
+      .run(exportAtom)
+      .records()
+      .pipe(
+        first(() => true, undefined),
+        map((r) => r?.get('graph') as Maybe<Array<IAtomDTO>>),
+      ),
+
+  importAtomFromJson: async (
+    atoms: Array<AtomInput>,
+  ): Promise<Array<CreateAtomsMutationResponse>> => {
+    const allAtomPromises: Array<CreateAtomsMutationResponse> =
+      await Promise.all(
+        atoms.map(async (atom) => {
+          const tagNames: Array<string> =
+            atom?.tags?.map((tag: Tag) => tag.name) || []
+
+          const tagConnects: Array<AtomTagsConnectFieldInput> = tagNames.map(
+            (name: string) => {
+              return { where: { node: { name } } }
+            },
+          )
+
+          const atomCreateInput: AtomCreateInput = {
+            id: v4(),
+            name: atom.name,
+            type: atom.type,
+            tags: {
+              connect: tagConnects,
+            },
+            api: {
+              connect: {
+                where: {
+                  node: {
+                    id: atom.api?.id,
+                  },
+                },
+              },
+            },
+          }
+
+          return (await AtomModel()).create({ input: [atomCreateInput] })
+        }),
+      )
+
+    return Promise.resolve(allAtomPromises)
+  },
+}

--- a/libs/backend/src/resolvers/common/withRxTransaction.ts
+++ b/libs/backend/src/resolvers/common/withRxTransaction.ts
@@ -2,9 +2,7 @@ import { IFieldResolver } from '@graphql-tools/utils/Interfaces'
 import { GraphQLResolveInfo } from 'graphql'
 import { RxTransaction } from 'neo4j-driver'
 import { Observable } from 'rxjs'
-import { getDriver } from '../../infra/driver'
-
-const driver = getDriver()
+import { getDriver } from '../../infra'
 
 export type IRxTxnResolver<
   TParent = any,
@@ -34,6 +32,7 @@ export const withRxTransaction = <
     context,
     info,
   ) => {
+    const driver = getDriver()
     const session = driver.rxSession()
 
     return session

--- a/libs/backend/src/resolvers/element/element.resolvers.ts
+++ b/libs/backend/src/resolvers/element/element.resolvers.ts
@@ -3,13 +3,12 @@ import { IFieldResolver } from '@graphql-tools/utils/Interfaces'
 import { getDriver } from '../../infra/driver'
 import { elementRepository } from '../../repositories'
 
-const driver = getDriver()
-
 export const elementGraph: IFieldResolver<
   any,
   any,
   QueryElementGraphArgs
 > = async (parent, args) => {
+  const driver = getDriver()
   const session = driver.rxSession()
 
   const $elementGraph = session.readTransaction((txn) =>

--- a/libs/backend/src/resolvers/index.ts
+++ b/libs/backend/src/resolvers/index.ts
@@ -1,1 +1,2 @@
+export * from './element/element.resolvers'
 export * from './resolvers'

--- a/libs/backend/src/selectionSets/appSelectionSet.ts
+++ b/libs/backend/src/selectionSets/appSelectionSet.ts
@@ -1,0 +1,1 @@
+export const appSelectionSet = `{ id, name, rootProviderElement { id } }`

--- a/libs/backend/src/selectionSets/index.ts
+++ b/libs/backend/src/selectionSets/index.ts
@@ -1,3 +1,4 @@
+export * from './appSelectionSet'
 export * from './componentSelectionSet'
 export * from './elementSelectionSet'
 export * from './pageSelectionSet'

--- a/libs/frontend/modules/builder/src/Builder.tsx
+++ b/libs/frontend/modules/builder/src/Builder.tsx
@@ -25,6 +25,7 @@ export const Builder = observer<BuilderProps>(
     return (
       <StyledBuilderContainer
         id="Builder"
+        key={builderService.builderRenderer.tree?.id}
         onClick={handleContainerClick}
         onMouseLeave={handleMouseLeave}
         onMouseOver={handleMouseOver}

--- a/libs/frontend/modules/type/src/store/models/any-type.interface.ts
+++ b/libs/frontend/modules/type/src/store/models/any-type.interface.ts
@@ -1,0 +1,26 @@
+import { AppType } from './app-type.model'
+import { ArrayType } from './array-type.model'
+import { ElementType } from './element-type.model'
+import { EnumType } from './enum-type.model'
+import { InterfaceType } from './interface-type.model'
+import { LambdaType } from './lambda-type.model'
+import { MonacoType } from './monaco-type.model'
+import { PageType } from './page-type.model'
+import { PrimitiveType } from './primitive-type.model'
+import { ReactNodeType } from './react-node-type.model'
+import { RenderPropsType } from './render-props-type.model'
+import { UnionType } from './union-type.model'
+
+export type AnyType =
+  | AppType
+  | ArrayType
+  | ElementType
+  | EnumType
+  | InterfaceType
+  | LambdaType
+  | MonacoType
+  | PageType
+  | PrimitiveType
+  | ReactNodeType
+  | RenderPropsType
+  | UnionType

--- a/libs/frontend/modules/type/src/store/type-import.service.ts
+++ b/libs/frontend/modules/type/src/store/type-import.service.ts
@@ -77,7 +77,7 @@ export class TypeImportService extends Model({}) {
     yield* _await(typeService.getAll())
 
     // keep a queue of types to create, so we can check for types that depend on other types
-    const queue: Array<AnyType> = payload as Array<AnyType>
+    const queue: Array<SnapshotOutOf<AnyType>> = payload
     const isInQueue = (id: string) => queue.some((t) => t.id === id)
     let i = 0
 

--- a/libs/frontend/modules/type/src/store/type-import.service.ts
+++ b/libs/frontend/modules/type/src/store/type-import.service.ts
@@ -114,7 +114,7 @@ export class TypeImportService extends Model({}) {
   })
 
   /** Returns the type ids which must be imported before this type is imported */
-  private getTypeDependantIds(type: AnyType): Array<string> {
+  private getTypeDependantIds(type: SnapshotOutOf<AnyType>): Array<string> {
     switch (type.kind) {
       case ITypeKind.UnionType:
         return type.typesOfUnionType.map((t) => t.id)
@@ -135,7 +135,7 @@ export class TypeImportService extends Model({}) {
   @transaction
   private upsertType = _async(function* (
     this: TypeImportService,
-    importedType: AnyType,
+    importedType: SnapshotOutOf<AnyType>,
     auth0Id: string,
   ) {
     const typeService = getTypeService(this)

--- a/libs/frontend/shared/utils/src/callbackWithParams.ts
+++ b/libs/frontend/shared/utils/src/callbackWithParams.ts
@@ -1,4 +1,4 @@
-import { Callback } from '@codelab/frontend/abstract/types'
+import type { Callback } from '@codelab/frontend/abstract/types'
 import { isFunction, isObjectLike } from 'lodash'
 import { ArrayOrSingle } from 'ts-essentials'
 

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "@types/findup-sync": "4.0.2",
     "@types/google-protobuf": "3.15.5",
     "@types/graphql-iso-date": "3.4.0",
+    "@types/inquirer": "^8.2.1",
     "@types/invariant": "2.2.35",
     "@types/jest": "27.4.0",
     "@types/jquery": "3.5.13",
@@ -309,6 +310,7 @@
     "execa": "^5",
     "get-port-cli": "^3.0.0",
     "glob": "7.2.0",
+    "inquirer": "^8.2.2",
     "jest": "27.5.1",
     "json-schema": "0.4.0",
     "lint-staged": "12.1.7",
@@ -332,6 +334,7 @@
     "url-loader": "4.1.1",
     "utility-types": "3.10.0",
     "wait-on": "6.0.0",
+    "webpack-merge": "^5.8.0",
     "why-is-node-running": "2.2.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9967,6 +9967,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/inquirer@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "@types/inquirer@npm:8.2.1"
+  dependencies:
+    "@types/through": "*"
+    rxjs: ^7.2.0
+  checksum: 5362d0b1cbec3887c9d5a671a0b19c58cf54066456c8967dd7ee799dfcc242cc8cd8959440c0f2fe7768becaf721b45fd30c222e6b9bcca378f45c68af43bab5
+  languageName: node
+  linkType: hard
+
 "@types/invariant@npm:2.2.35":
   version: 2.2.35
   resolution: "@types/invariant@npm:2.2.35"
@@ -10601,6 +10611,15 @@ __metadata:
   dependencies:
     "@types/jest": "*"
   checksum: 203443d0e7e5929fbc9e441146f92d85efa033b4697e427ed0164df1c40b720b6bb9bbd96a3171ea5fd8d9301b538fd0f49d4f35594d142afd0f6d2ecac25785
+  languageName: node
+  linkType: hard
+
+"@types/through@npm:*":
+  version: 0.0.30
+  resolution: "@types/through@npm:0.0.30"
+  dependencies:
+    "@types/node": "*"
+  checksum: 9578470db0b527c26e246a1220ae9bffc6bf47f20f89c54aac467c083ab1f7e16c00d9a7b4bb6cb4e2dfae465027270827e5908a6236063f6214625e50585d78
   languageName: node
   linkType: hard
 
@@ -14696,6 +14715,7 @@ __metadata:
     "@types/findup-sync": 4.0.2
     "@types/google-protobuf": 3.15.5
     "@types/graphql-iso-date": 3.4.0
+    "@types/inquirer": ^8.2.1
     "@types/invariant": 2.2.35
     "@types/jest": 27.4.0
     "@types/jquery": 3.5.13
@@ -14799,6 +14819,7 @@ __metadata:
     graphql-tools: 8.2.0
     graphql-type-json: 0.3.2
     husky: 7.0.4
+    inquirer: ^8.2.2
     io-ts: 2.2.16
     jest: 27.5.1
     jquery: 3.6.0
@@ -14869,6 +14890,7 @@ __metadata:
     voca: 1.4.0
     vscode-css-languageservice: 5.1.9
     wait-on: 6.0.0
+    webpack-merge: ^5.8.0
     why-is-node-running: 2.2.0
     worker-loader: 3.0.8
     yargs: 17.3.1
@@ -22019,7 +22041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inquirer@npm:^8.0.0":
+"inquirer@npm:^8.0.0, inquirer@npm:^8.2.2":
   version: 8.2.2
   resolution: "inquirer@npm:8.2.2"
   dependencies:
@@ -31418,7 +31440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.1.0, rxjs@npm:^7.5.1, rxjs@npm:^7.5.5":
+"rxjs@npm:^7.1.0, rxjs@npm:^7.2.0, rxjs@npm:^7.5.1, rxjs@npm:^7.5.5":
   version: 7.5.5
   resolution: "rxjs@npm:7.5.5"
   dependencies:


### PR DESCRIPTION
Fixes #1543 

Adds 'import-app' and 'export-app' commands to the cli.
To test:
`yarn cli export-app` and `yarn cli import-app path/to/json-file`