### PR TITLE
Changing the component of an element error

### DIFF
--- a/libs/frontend/modules/element/src/store/api.utils.ts
+++ b/libs/frontend/modules/element/src/store/api.utils.ts
@@ -124,7 +124,10 @@ export const makeUpdateInput = (
     : { disconnect: { where: {} } }
 
   const instanceOfComponent = input.instanceOfComponentId
-    ? { connect: { where: { node: { id: input.instanceOfComponentId } } } }
+    ? {
+        disconnect: { where: {} },
+        connect: { where: { node: { id: input.instanceOfComponentId } } },
+      }
     : { disconnect: { where: {} } }
 
   return {


### PR DESCRIPTION
## Description (Optional)
Apparently Neo4j is rejecting the update query because it is asking to add another component for INSTANCE_OF_COMPONENT of an element, which is not allowed. We need to first remove the current one then add the new one. 

## Related Issue(s)
related #1630 


https://user-images.githubusercontent.com/51242349/177499407-a245110b-b8a5-4bfa-86de-223eefa0744f.mp4


