### PR TITLE
Fix ElementService interface/class mismatch

### DIFF
--- a/libs/frontend/modules/element/src/store/element.service.ts
+++ b/libs/frontend/modules/element/src/store/element.service.ts
@@ -20,7 +20,7 @@ import {
   IUpdateElementDTO,
   IUpdatePropMapBindingDTO,
 } from '@codelab/shared/abstract/core'
-import { IEntity } from '@codelab/shared/abstract/types'
+import { IEntity, Nullable } from '@codelab/shared/abstract/types'
 import {
   _async,
   _await,
@@ -434,7 +434,7 @@ export class ElementService
     this: ElementService,
     element: Element,
     auth0Id: IAuth0Id,
-    elementTree: IElementTree,
+    elementTree: Nullable<IElementTree>,
   ) {
     if (!element.parentElement) {
       throw new Error("Can't convert root element")

--- a/libs/shared/abstract/core/src/domain/element/element.service.interface.ts
+++ b/libs/shared/abstract/core/src/domain/element/element.service.interface.ts
@@ -2,7 +2,7 @@ import {
   ElementUpdateInput,
   ElementWhere,
 } from '@codelab/shared/abstract/codegen'
-import { Maybe } from '@codelab/shared/abstract/types'
+import { Maybe, Nullable } from '@codelab/shared/abstract/types'
 import { ObjectMap, Ref } from 'mobx-keystone'
 import {
   ICRUDModalService,
@@ -80,7 +80,11 @@ export interface IElementService
     auth0Id: IAuth0Id,
     elementTree: IElementTree | null,
   ): Promise<void>
-  convertElementToComponent(element: IElement, auth0Id: IAuth0Id): Promise<void>
+  convertElementToComponent(
+    element: IElement,
+    auth0Id: IAuth0Id,
+    elementTree: Nullable<IElementTree>,
+  ): Promise<void>
   element(id: string): Maybe<IElement>
 
   updateElementsPropTransformationJs(


### PR DESCRIPTION
## Description
There seem to have been a mismatch between the new param of `ElementService.convertElementToComponent` and the one of `IElementService.convertElementToComponent` in #1638 causing all CI to fail.

## Related Issue(s)
